### PR TITLE
Progress bar polyfill

### DIFF
--- a/src/components/TimerProgressBar/index.js
+++ b/src/components/TimerProgressBar/index.js
@@ -4,9 +4,13 @@ import './index.styl'
 function TimerProgressBar(props) {
 	const { remainingSeconds, totalSeconds } = props
 	const percent = remainingSeconds * 100 / totalSeconds
+	const percentPolyfill = percent / 2 + '%'
 
 	return (
-		<progress className="TimerProgressBar" max={totalSeconds} value={remainingSeconds}>{percent}%</progress>
+		<div className="progressBarWrapper">
+			<progress className="TimerProgressBar" max={totalSeconds} value={remainingSeconds}>{percent}%</progress>
+			<span className="progressBarPolyfill" style={{width:percentPolyfill}}></span>
+		</div>
 	)
 }
 

--- a/src/components/TimerProgressBar/index.styl
+++ b/src/components/TimerProgressBar/index.styl
@@ -1,14 +1,18 @@
+.progressBarWrapper
+	position relative
+
 .TimerProgressBar
 	appearance none
+	background-color red
 	border none
 	border-radius 2px
 	display block
+	height 1.05rem
 	margin-bottom 1rem
-	transition all 1s ease
 	width 50%
 
 	&[value]::-webkit-progress-bar
-		background-color whitesmoke
+		background-color red
 		border-radius 2px
 
 	&[value]::-webkit-progress-value
@@ -16,6 +20,15 @@
 		transition width 1s linear
 
 	&[value]::-moz-progress-bar
-		background-image -moz-linear-gradient(top, rgba(255, 255, 255, .25), rgba(0, 0, 0, .25)), -moz-linear-gradient(left, blue, purple)
-		border-radius 2px
+		background-color transparent
+		// background-image -moz-linear-gradient(top, rgba(255, 255, 255, .25), rgba(0, 0, 0, .25)), -moz-linear-gradient(left, blue, purple)
 		background-size 35px 20px, 100% 100%, 100% 100%
+		border-radius 2px
+
+.progressBarPolyfill
+	background-color white
+	clip-path polygon(0 0, 100% 0, 100% 100%, 0 100%)
+	height 1.05rem
+	position absolute
+	top 0
+	transition width 1s linear

--- a/src/components/TimerProgressBar/index.styl
+++ b/src/components/TimerProgressBar/index.styl
@@ -3,16 +3,17 @@
 
 .TimerProgressBar
 	appearance none
-	background-color red
+	background-color white
 	border none
 	border-radius 2px
 	display block
-	height 1.05rem
+	height 1rem
 	margin-bottom 1rem
+	transform rotate(180deg)
 	width 50%
 
 	&[value]::-webkit-progress-bar
-		background-color red
+		background-color white
 		border-radius 2px
 
 	&[value]::-webkit-progress-value
@@ -26,9 +27,10 @@
 		border-radius 2px
 
 .progressBarPolyfill
-	background-color white
+	background-color red
 	clip-path polygon(0 0, 100% 0, 100% 100%, 0 100%)
-	height 1.05rem
+	height 1rem
 	position absolute
+	right 50%
 	top 0
 	transition width 1s linear


### PR DESCRIPTION
Added wrapper div and polyfill for timer progress bar since transition doesn't work for ::-moz-progress-bar. A span takes care of the linear transition considering Firefox's handicap.